### PR TITLE
Validate user name in web_service before using it in file name

### DIFF
--- a/web_service/beaqleJS_Service.php
+++ b/web_service/beaqleJS_Service.php
@@ -30,6 +30,11 @@
             // generate filename
             if (isset($_POST['username']) && (strlen($_POST['username'])<128)) {
                 $username = $_POST['username'];
+                $username = str_replace(' ', '_',  $username);
+                // Remove anything from the username which isnt a standard letter, number, _ or -.
+                // This is necessary to avoid path injection
+                // because the username is used within the file name.
+                $username = preg_replace('/[^a-zA-Z0-9_-]/s', '',  $username);
             } else {
                 $username = "";
             }


### PR DESCRIPTION
I wasn't feeling well running a service that allows anyone to create files on the server with arbitrary characters in their names. Now it's restricted to standard English characters plus numbers, dashes and underscores. Spaces are replaced by _.
For example imagine a username like "/../../../somewhere/else/" might allow an attacker to write in any other directory if the server permissions are miss-configured. It's still unlikely it would work given the file name has a date-prefix but its never the less a good idea to always validate user input.