### PR TITLE
Add "Repeat" and "GroupRepeated" options

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,55 +1,91 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
-  <title></title>
-  <style type="text/css">code{white-space: pre;}</style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>README</title>
   <style type="text/css">
-div.sourceCode { overflow-x: auto; }
-table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
-  margin: 0; padding: 0; vertical-align: baseline; border: none; }
-table.sourceCode { width: 100%; line-height: 100%; }
-td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
-td.sourceCode { padding-left: 5px; }
-code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
-code > span.dt { color: #902000; } /* DataType */
-code > span.dv { color: #40a070; } /* DecVal */
-code > span.bn { color: #40a070; } /* BaseN */
-code > span.fl { color: #40a070; } /* Float */
-code > span.ch { color: #4070a0; } /* Char */
-code > span.st { color: #4070a0; } /* String */
-code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
-code > span.ot { color: #007020; } /* Other */
-code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
-code > span.fu { color: #06287e; } /* Function */
-code > span.er { color: #ff0000; font-weight: bold; } /* Error */
-code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-code > span.cn { color: #880000; } /* Constant */
-code > span.sc { color: #4070a0; } /* SpecialChar */
-code > span.vs { color: #4070a0; } /* VerbatimString */
-code > span.ss { color: #bb6688; } /* SpecialString */
-code > span.im { } /* Import */
-code > span.va { color: #19177c; } /* Variable */
-code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-code > span.op { color: #666666; } /* Operator */
-code > span.bu { } /* BuiltIn */
-code > span.ex { } /* Extension */
-code > span.pp { color: #bc7a00; } /* Preprocessor */
-code > span.at { color: #7d9029; } /* Attribute */
-code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
-code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <style type="text/css">
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; position: absolute; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; }
+pre.numberSource a.sourceLine:empty
+  { position: absolute; }
+pre.numberSource a.sourceLine::before
+  { content: attr(data-line-number);
+    position: absolute; left: -5em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
-<div id="header">
+<header>
 <h1 class="title">BeaqleJS Documentation</h1>
-</div>
+</header>
 <p>Table of contents</p>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><a href="#1-description">Description</a></li>
 <li><a href="#2-basic-setup">Basic Setup</a></li>
 <li><a href="#3-test-configuration">Test Configuration</a></li>
@@ -69,14 +105,14 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <p>BeaqleJS has been presented at the <a href="http://lac.linuxaudio.org/2014/">Linux Audio Conference 2014</a> at the ZKM in Karlsruhe, Germany. The original <a href="http://lac.linuxaudio.org/2014/papers/26.pdf">paper</a> and presentation <a href="http://lac.linuxaudio.org/2014/download/SKraft_BeaqleJS.pdf">slides</a> are available from the conference archive. However, meanwhile most of the paper content has been updated and merged into this documentation.</p>
 <p>If you want to cite BeaqleJS in a publication please use</p>
 <blockquote>
-<p>S. Kraft, U. Zölzer: &quot;BeaqleJS: HTML5 and JavaScript based Framework for the Subjective Evaluation of Audio Quality&quot;, <em>Linux Audio Conference</em>, 2014, Karlsruhe, Germany</p>
+<p>S. Kraft, U. Zölzer: “BeaqleJS: HTML5 and JavaScript based Framework for the Subjective Evaluation of Audio Quality”, <em>Linux Audio Conference</em>, 2014, Karlsruhe, Germany</p>
 </blockquote>
 <p>as a reference or link to our GitHub repository</p>
 <blockquote>
 <p>https://github.com/HSU-ANT/beaqlejs</p>
 </blockquote>
 <h1 id="basic-setup">2. Basic Setup</h1>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li>Download the test scripts
 <ul>
 <li>you can either get a stable release from<br />
@@ -87,18 +123,18 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <a href="https://github.com/HSU-ANT/beaqlejs/archive/master.zip" class="uri">https://github.com/HSU-ANT/beaqlejs/archive/master.zip</a></li>
 </ul></li>
 <li><p>Uncomment the line where the desired test class is initialized and loaded in the header of the <code>index.html</code> file.</p>
-<div class="sourceCode"><pre class="sourceCode html"><code class="sourceCode html"><span class="kw">&lt;script</span><span class="ot"> type=</span><span class="st">&quot;text/javascript&quot;</span><span class="kw">&gt;</span>
-  <span class="kw">var</span> testHandle<span class="op">;</span>
-  <span class="va">window</span>.<span class="at">onload</span><span class="op">=</span><span class="kw">function</span>() <span class="op">{</span>
-    <span class="co">// Uncomment one of the following lines to choose the desired test class</span>
-    <span class="co">//testHandle = new MushraTest(TestConfig);  // &lt;= MUSHRA test class</span>
-    <span class="co">//testHandle = new AbxTest(TestConfig);     // &lt;= ABX test class</span>
-  <span class="op">};</span>
-<span class="op">&lt;</span><span class="ss">/script&gt;</span></code></pre></div></li>
+<div class="sourceCode" id="cb1"><pre class="sourceCode html"><code class="sourceCode html"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw">&lt;script</span><span class="ot"> type=</span><span class="st">&quot;text/javascript&quot;</span><span class="kw">&gt;</span></a>
+<a class="sourceLine" id="cb1-2" data-line-number="2">  <span class="kw">var</span> testHandle<span class="op">;</span></a>
+<a class="sourceLine" id="cb1-3" data-line-number="3">  <span class="va">window</span>.<span class="at">onload</span><span class="op">=</span><span class="kw">function</span>() <span class="op">{</span></a>
+<a class="sourceLine" id="cb1-4" data-line-number="4">    <span class="co">// Uncomment one of the following lines to choose the desired test class</span></a>
+<a class="sourceLine" id="cb1-5" data-line-number="5">    <span class="co">//testHandle = new MushraTest(TestConfig);  // &lt;= MUSHRA test class</span></a>
+<a class="sourceLine" id="cb1-6" data-line-number="6">    <span class="co">//testHandle = new AbxTest(TestConfig);     // &lt;= ABX test class</span></a>
+<a class="sourceLine" id="cb1-7" data-line-number="7">  <span class="op">};</span></a>
+<a class="sourceLine" id="cb1-8" data-line-number="8"><span class="kw">&lt;/script&gt;</span></a></code></pre></div></li>
 <li><p>Prepare a config file and set its path in the prepared <code>&lt;script&gt;&lt;/script&gt;</code> tag in the header of the <code>index.html</code> file.</p>
-<div class="sourceCode"><pre class="sourceCode html"><code class="sourceCode html"><span class="co">&lt;!-- load the test config file --&gt;</span>
-  <span class="kw">&lt;script</span><span class="ot"> src=</span><span class="st">&quot;config/YOUR_CONFIG.js&quot;</span><span class="ot"> type=</span><span class="st">&quot;text/javascript&quot;</span><span class="kw">&gt;&lt;/script&gt;</span>
-<span class="co">&lt;!----&gt;</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode html"><code class="sourceCode html"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="co">&lt;!-- load the test config file --&gt;</span></a>
+<a class="sourceLine" id="cb2-2" data-line-number="2">  <span class="kw">&lt;script</span><span class="ot"> src=</span><span class="st">&quot;config/YOUR_CONFIG.js&quot;</span><span class="ot"> type=</span><span class="st">&quot;text/javascript&quot;</span><span class="kw">&gt;&lt;/script&gt;</span></a>
+<a class="sourceLine" id="cb2-3" data-line-number="3"><span class="co">&lt;!----&gt;</span></a></code></pre></div>
 <p>Two example config files for the MUSHRA and ABX test class are already supplied in the <code>config/</code> folder to serve as a starting point. Detailed information about the different test classes and configuration can be found below.</p></li>
 </ol>
 <h2 id="docker-webserver">2.1 Docker Webserver</h2>
@@ -130,66 +166,71 @@ $&gt; docker-compose stop</code></pre>
 <h1 id="test-configuration">3. Test Configuration</h1>
 <h2 id="general-options">3.1 General Options</h2>
 <p>The available options can be divided into a set of general options which apply to all test classes and other options, including file declarations, that are specific for a single test class.</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="kw">var</span> TestConfig <span class="op">=</span> <span class="op">{</span>
-  <span class="st">&quot;TestName&quot;</span><span class="op">:</span> <span class="st">&quot;My Listening Test&quot;</span><span class="op">,</span>   <span class="co">// &lt;=  Name of the test</span>
-  <span class="st">&quot;LoopByDefault&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>             <span class="co">// &lt;=  Enable looped playback by default</span>
-  <span class="st">&quot;AutoReturnByDefault&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>       <span class="co">// &lt;=  Always start playback from loop/track begin</span>
-  <span class="st">&quot;ShowFileIDs&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>              <span class="co">// &lt;=  Show file IDs for debugging (never</span>
-                                     <span class="co">//     enable this during real test!)</span>
-  <span class="st">&quot;ShowResults&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>              <span class="co">// &lt;=  Show table with test results at the end</span>
-  <span class="st">&quot;EnableABLoop&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>              <span class="co">// &lt;=  Show controls to loop playback with an</span>
-                                     <span class="co">//     AB range slider</span>
-  <span class="st">&quot;EnableOnlineSubmission&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>   <span class="co">// &lt;=  Enable transmission of JSON encoded</span>
-                                     <span class="co">//     results to a web service</span>
-  <span class="st">&quot;BeaqleServiceURL&quot;</span><span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">,</span>            <span class="co">// &lt;=  URL of the web service</span>
-  <span class="st">&quot;SupervisorContact&quot;</span><span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">,</span>           <span class="co">// &lt;=  Email address of supervisor to contact for</span>
-                                     <span class="co">//     help or for submission of results by email</span>
-  <span class="st">&quot;RandomizeTestOrder&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>        <span class="co">// &lt;=  Present test sets in a random order</span>
-  <span class="st">&quot;MaxTestsPerRun&quot;</span><span class="op">:</span> <span class="op">-</span><span class="dv">1</span><span class="op">,</span>              <span class="co">// &lt;=  Only run a random subset of all available</span>
-                                     <span class="co">//     tests, set to -1 to disable</span>
-  <span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [ <span class="op">{</span>...<span class="op">},</span> <span class="op">{</span>...<span class="op">},</span> ... ]<span class="op">,</span> <span class="co">// &lt;=  Definition of test sets and files, more</span>
-                                     <span class="co">//     details below</span>
-<span class="op">}</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode javascript"><code class="sourceCode javascript"><a class="sourceLine" id="cb12-1" data-line-number="1"><span class="kw">var</span> TestConfig <span class="op">=</span> <span class="op">{</span></a>
+<a class="sourceLine" id="cb12-2" data-line-number="2">  <span class="st">&quot;TestName&quot;</span><span class="op">:</span> <span class="st">&quot;My Listening Test&quot;</span><span class="op">,</span>   <span class="co">// &lt;=  Name of the test</span></a>
+<a class="sourceLine" id="cb12-3" data-line-number="3">  <span class="st">&quot;LoopByDefault&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>             <span class="co">// &lt;=  Enable looped playback by default</span></a>
+<a class="sourceLine" id="cb12-4" data-line-number="4">  <span class="st">&quot;AutoReturnByDefault&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>       <span class="co">// &lt;=  Always start playback from loop/track begin</span></a>
+<a class="sourceLine" id="cb12-5" data-line-number="5">  <span class="st">&quot;ShowFileIDs&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>              <span class="co">// &lt;=  Show file IDs for debugging (never</span></a>
+<a class="sourceLine" id="cb12-6" data-line-number="6">                                     <span class="co">//     enable this during real test!)</span></a>
+<a class="sourceLine" id="cb12-7" data-line-number="7">  <span class="st">&quot;ShowResults&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>              <span class="co">// &lt;=  Show table with test results at the end</span></a>
+<a class="sourceLine" id="cb12-8" data-line-number="8">  <span class="st">&quot;EnableABLoop&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>              <span class="co">// &lt;=  Show controls to loop playback with an</span></a>
+<a class="sourceLine" id="cb12-9" data-line-number="9">                                     <span class="co">//     AB range slider</span></a>
+<a class="sourceLine" id="cb12-10" data-line-number="10">  <span class="st">&quot;EnableOnlineSubmission&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>   <span class="co">// &lt;=  Enable transmission of JSON encoded</span></a>
+<a class="sourceLine" id="cb12-11" data-line-number="11">                                     <span class="co">//     results to a web service</span></a>
+<a class="sourceLine" id="cb12-12" data-line-number="12">  <span class="st">&quot;BeaqleServiceURL&quot;</span><span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">,</span>            <span class="co">// &lt;=  URL of the web service</span></a>
+<a class="sourceLine" id="cb12-13" data-line-number="13">  <span class="st">&quot;SupervisorContact&quot;</span><span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">,</span>           <span class="co">// &lt;=  Email address of supervisor to contact for</span></a>
+<a class="sourceLine" id="cb12-14" data-line-number="14">                                     <span class="co">//     help or for submission of results by email</span></a>
+<a class="sourceLine" id="cb12-15" data-line-number="15">  <span class="st">&quot;RandomizeTestOrder&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>        <span class="co">// &lt;=  Present test sets in a random order</span></a>
+<a class="sourceLine" id="cb12-16" data-line-number="16">  <span class="st">&quot;MaxTestsPerRun&quot;</span><span class="op">:</span> <span class="dv">-1</span><span class="op">,</span>              <span class="co">// &lt;=  Only run a random subset of all available</span></a>
+<a class="sourceLine" id="cb12-17" data-line-number="17">                                     <span class="co">//     tests, set to -1 to disable</span></a>
+<a class="sourceLine" id="cb12-18" data-line-number="18">  <span class="st">&quot;AudioRoot&quot;</span><span class="op">:</span> <span class="st">&quot;&quot;</span><span class="op">,</span>                   <span class="co">// &lt;=  path to prepend to all audio URLs in the testsets</span></a>
+<a class="sourceLine" id="cb12-19" data-line-number="19">  <span class="st">&quot;Repeat&quot;</span><span class="op">:</span> <span class="dv">1</span><span class="op">,</span>                       <span class="co">// &lt;=  Each testset will be repeated x times</span></a>
+<a class="sourceLine" id="cb12-20" data-line-number="20">  <span class="st">&quot;GroupRepeated&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>             <span class="co">// &lt;=  If set to false, automatically replicated testsets gets split apart when randomization is enabled</span></a>
+<a class="sourceLine" id="cb12-21" data-line-number="21">  <span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [ <span class="op">{</span>...<span class="op">},</span> <span class="op">{</span>...<span class="op">},</span> ... ]<span class="op">,</span> <span class="co">// &lt;=  Definition of test sets and files, more</span></a>
+<a class="sourceLine" id="cb12-22" data-line-number="22">                                     <span class="co">//     details below</span></a>
+<a class="sourceLine" id="cb12-23" data-line-number="23"><span class="op">}</span></a></code></pre></div>
 <h2 id="abx">3.2 ABX</h2>
 <p>In an ABX test three items named A, B and X are presented to the listener, whereas X is randomly selected to be either the same as A or B. The listener has to identify which item is hidden behind X, or which one (A or B) is closest to X. If the listener is able to find the correct item, it reveals that there are perceptual differences between A and B.</p>
 <p>A typical application of ABX tests would be the evaluation of the transparency of audio codecs. For example item A could be an unencoded audio snippet and B is the same snippet but encoded with a lossy codec. When the listener is not able to identify if A or B was hidden in X (results are randomly distributed), one can assume that the audio coding was transparent</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript">...                                  <span class="co">// &lt;=  General options</span>
-<span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [
-  <span class="op">{</span> <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Schubert&quot;</span><span class="op">,</span>              <span class="co">// &lt;=  Name of the test set</span>
-    <span class="st">&quot;TestID&quot;</span><span class="op">:</span> <span class="st">&quot;id1_1&quot;</span><span class="op">,</span>               <span class="co">// &lt;=  Unique test set ID, necessary for internal</span>
-    <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span>                       <span class="co">// &lt;=  Array with test files</span>
-      <span class="st">&quot;A&quot;</span><span class="op">:</span> <span class="st">&quot;audio/schubert_ref.wav&quot;</span><span class="op">,</span> <span class="co">// &lt;=  File A</span>
-      <span class="st">&quot;B&quot;</span><span class="op">:</span> <span class="st">&quot;audio/schubert_2.wav&quot;</span><span class="op">,</span>   <span class="co">// &lt;=  File B</span>
-      <span class="op">}</span>
-  <span class="op">},</span>
-  <span class="op">{</span> ... <span class="op">},</span>                           <span class="co">// &lt;=  Next test set starts here</span>
-  ....
-]</code></pre></div>
-<h2 id="mushra">3.3 MUSHRA</h2>
+<div class="sourceCode" id="cb13"><pre class="sourceCode javascript"><code class="sourceCode javascript"><a class="sourceLine" id="cb13-1" data-line-number="1">...                                  <span class="co">// &lt;=  General options</span></a>
+<a class="sourceLine" id="cb13-2" data-line-number="2"><span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [</a>
+<a class="sourceLine" id="cb13-3" data-line-number="3">  <span class="op">{</span> <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Schubert&quot;</span><span class="op">,</span>              <span class="co">// &lt;=  Name of the test set</span></a>
+<a class="sourceLine" id="cb13-4" data-line-number="4">    <span class="st">&quot;TestID&quot;</span><span class="op">:</span> <span class="st">&quot;id1_1&quot;</span><span class="op">,</span>               <span class="co">// &lt;=  Unique test set ID, necessary for internal</span></a>
+<a class="sourceLine" id="cb13-5" data-line-number="5">    <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span>                       <span class="co">// &lt;=  Array with test files</span></a>
+<a class="sourceLine" id="cb13-6" data-line-number="6">      <span class="st">&quot;A&quot;</span><span class="op">:</span> <span class="st">&quot;audio/schubert_ref.wav&quot;</span><span class="op">,</span> <span class="co">// &lt;=  File A</span></a>
+<a class="sourceLine" id="cb13-7" data-line-number="7">      <span class="st">&quot;B&quot;</span><span class="op">:</span> <span class="st">&quot;audio/schubert_2.wav&quot;</span><span class="op">,</span>   <span class="co">// &lt;=  File B</span></a>
+<a class="sourceLine" id="cb13-8" data-line-number="8">      <span class="op">}</span></a>
+<a class="sourceLine" id="cb13-9" data-line-number="9">  <span class="op">},</span></a>
+<a class="sourceLine" id="cb13-10" data-line-number="10">  <span class="op">{</span> ... <span class="op">},</span>                           <span class="co">// &lt;=  Next test set starts here</span></a>
+<a class="sourceLine" id="cb13-11" data-line-number="11">  ....</a>
+<a class="sourceLine" id="cb13-12" data-line-number="12">]</a></code></pre></div>
+<h2 id="preference-testing">3.3 Preference Testing</h2>
+<p>A preference test (or A/B test) is a simplified version of ABX in which the listener is to decide which of two stimuli sounds better. A typical application of preference tests would be the comparison of different speech synthesis methods. Over a range of stimuli and listeners, one method (A or B) might be shown to be better than the other (one might use a sign test for comparison of results for A and B). Configuration is identical to the ABX test; however, no X is presented to the user.</p>
+<h2 id="mushra">3.4 MUSHRA</h2>
 <p>In a MUSHRA test (ITU-R BS.1116-1) the listener gets presented an item marked as reference together with several anonymous test items. By using a slider for each test item he has to rate how close the items are to the reference on top. Among the test items there is usually also one hidden reference and one, or several, anchor signals to prove the validity of the ratings and the qualification of the participants.</p>
 <p>Contrary to ABX tests the MUSHRA procedure allows more detailed evaluations as it is possible to compare more than one algorithm to a reference. Furthermore, the results are on a continuous scale allowing a direct numerical comparison of all algorithms under test.</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript">...                                   <span class="co">// &lt;=  General options</span>
-<span class="st">&quot;RateMinValue&quot;</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span>                    <span class="co">// &lt;=  Minimum rating</span>
-<span class="st">&quot;RateMaxValue&quot;</span><span class="op">:</span> <span class="dv">100</span><span class="op">,</span>                  <span class="co">// &lt;=  Maximum rating</span>
-<span class="st">&quot;RateDefaultValue&quot;</span><span class="op">:</span><span class="dv">0</span><span class="op">,</span>                 <span class="co">// &lt;=  Default rating</span>
-<span class="st">&quot;RequireMaxRating&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>            <span class="co">// &lt;=  At least one of the ratings in a testset</span>
-                                      <span class="co">//     has to be at the maximum value</span>
-<span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [
-  <span class="op">{</span> <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Schubert 1&quot;</span><span class="op">,</span>             <span class="co">// &lt;=  Name of the test set</span>
-    <span class="st">&quot;TestID&quot;</span><span class="op">:</span> <span class="st">&quot;id1_1&quot;</span><span class="op">,</span>                <span class="co">// &lt;=  Unique test set ID, necessary for</span>
-                                      <span class="co">//     internal referencing</span>
-    <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span>                        <span class="co">// &lt;=  Array with test files</span>
-      <span class="st">&quot;Reference&quot;</span><span class="op">:</span> <span class="st">&quot;audio/ref.wav&quot;</span><span class="op">,</span>   <span class="co">// &lt;=  Every MUSHRA test set needs exactly</span>
-                                      <span class="co">//     one(!) file with a &quot;Reference&quot; label</span>
-      <span class="st">&quot;label_1&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_1.wav&quot;</span><span class="op">,</span>  <span class="co">// &lt;=  Various files to be tested, the labels</span>
-      <span class="st">&quot;label_2&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_2.wav&quot;</span><span class="op">,</span>  <span class="co">//     can be freely chosen as desired but</span>
-      <span class="st">&quot;label_3&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_3.wav&quot;</span><span class="op">,</span>  <span class="co">//     have to be unique inside a test set</span>
-      <span class="st">&quot;anchor&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_anc.wav&quot;</span><span class="op">,</span> <span class="co">//      ...</span>
-      <span class="op">}</span>
-  <span class="op">},</span>
-  <span class="op">{</span> ... <span class="op">},</span>                            <span class="co">// &lt;=  Next test set starts here</span>
-  ....
-]</code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode javascript"><code class="sourceCode javascript"><a class="sourceLine" id="cb14-1" data-line-number="1">...                                   <span class="co">// &lt;=  General options</span></a>
+<a class="sourceLine" id="cb14-2" data-line-number="2"><span class="st">&quot;RateMinValue&quot;</span><span class="op">:</span> <span class="dv">0</span><span class="op">,</span>                    <span class="co">// &lt;=  Minimum rating</span></a>
+<a class="sourceLine" id="cb14-3" data-line-number="3"><span class="st">&quot;RateMaxValue&quot;</span><span class="op">:</span> <span class="dv">100</span><span class="op">,</span>                  <span class="co">// &lt;=  Maximum rating</span></a>
+<a class="sourceLine" id="cb14-4" data-line-number="4"><span class="st">&quot;RateDefaultValue&quot;</span><span class="op">:</span><span class="dv">0</span><span class="op">,</span>                 <span class="co">// &lt;=  Default rating</span></a>
+<a class="sourceLine" id="cb14-5" data-line-number="5"><span class="st">&quot;RequireMaxRating&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>            <span class="co">// &lt;=  At least one of the ratings in a testset</span></a>
+<a class="sourceLine" id="cb14-6" data-line-number="6">                                      <span class="co">//     has to be at the maximum value</span></a>
+<a class="sourceLine" id="cb14-7" data-line-number="7"><span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [</a>
+<a class="sourceLine" id="cb14-8" data-line-number="8">  <span class="op">{</span> <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Schubert 1&quot;</span><span class="op">,</span>             <span class="co">// &lt;=  Name of the test set</span></a>
+<a class="sourceLine" id="cb14-9" data-line-number="9">    <span class="st">&quot;TestID&quot;</span><span class="op">:</span> <span class="st">&quot;id1_1&quot;</span><span class="op">,</span>                <span class="co">// &lt;=  Unique test set ID, necessary for</span></a>
+<a class="sourceLine" id="cb14-10" data-line-number="10">                                      <span class="co">//     internal referencing</span></a>
+<a class="sourceLine" id="cb14-11" data-line-number="11">    <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span>                        <span class="co">// &lt;=  Array with test files</span></a>
+<a class="sourceLine" id="cb14-12" data-line-number="12">      <span class="st">&quot;Reference&quot;</span><span class="op">:</span> <span class="st">&quot;audio/ref.wav&quot;</span><span class="op">,</span>   <span class="co">// &lt;=  Every MUSHRA test set needs exactly</span></a>
+<a class="sourceLine" id="cb14-13" data-line-number="13">                                      <span class="co">//     one(!) file with a &quot;Reference&quot; label</span></a>
+<a class="sourceLine" id="cb14-14" data-line-number="14">      <span class="st">&quot;label_1&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_1.wav&quot;</span><span class="op">,</span>  <span class="co">// &lt;=  Various files to be tested, the labels</span></a>
+<a class="sourceLine" id="cb14-15" data-line-number="15">      <span class="st">&quot;label_2&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_2.wav&quot;</span><span class="op">,</span>  <span class="co">//     can be freely chosen as desired but</span></a>
+<a class="sourceLine" id="cb14-16" data-line-number="16">      <span class="st">&quot;label_3&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_3.wav&quot;</span><span class="op">,</span>  <span class="co">//     have to be unique inside a test set</span></a>
+<a class="sourceLine" id="cb14-17" data-line-number="17">      <span class="st">&quot;anchor&quot;</span><span class="op">:</span> <span class="st">&quot;audio/algo_anc.wav&quot;</span><span class="op">,</span> <span class="co">//      ...</span></a>
+<a class="sourceLine" id="cb14-18" data-line-number="18">      <span class="op">}</span></a>
+<a class="sourceLine" id="cb14-19" data-line-number="19">  <span class="op">},</span></a>
+<a class="sourceLine" id="cb14-20" data-line-number="20">  <span class="op">{</span> ... <span class="op">},</span>                            <span class="co">// &lt;=  Next test set starts here</span></a>
+<a class="sourceLine" id="cb14-21" data-line-number="21">  ....</a>
+<a class="sourceLine" id="cb14-22" data-line-number="22">]</a></code></pre></div>
 <h1 id="browser-support">4. Browser Support</h1>
 <p>BeaqleJS in general will run well in any recent web browser out in the wild. The only noteworthy exceptions are the Internet Explorer versions below 9 which still have a market share of a few percent and unfortunately miss the required FileAPI. Participants will get a warning if they open the listening test with one of these old versions.</p>
 <h2 id="required-html5-features">4.1 Required HTML5 Features</h2>
@@ -269,7 +310,7 @@ $&gt; docker-compose stop</code></pre>
 <h1 id="online-submission">5. Online Submission</h1>
 <p>BeaqleJS can send the test results in JSON format to a web service to collect them in a central place. An exemplary server side PHP script which can be used to receive and store the results is included in the <code>web_service/</code> subfolder. It only requires a webspace with PHP &gt;= 5.6.</p>
 <h2 id="setup">5.1 Setup</h2>
-<ol style="list-style-type: decimal">
+<ol type="1">
 <li><p>Upload the file <code>web_service/beaqleJS_Service.php</code> to a webserver. Create a folder named <code>results/</code> next to the PHP script and make sure that the webserver has write permissions on it.</p></li>
 <li><p>Try to execute the script in your browser. For example, point your browser to <code>http://yourdomain.com/mysubfolder/beaqleJS_Service.php</code>. The script performs a self-test and checks PHP version and write permission of the <code>results/</code> folder.</p></li>
 <li><p>Enable online submission in the BeaqleJS config (<code>&quot;EnableOnlineSubmission&quot;: true</code>) and set the <code>BeaqleServiceURL</code> to <code>http://yourdomain.com/mysubfolder/beaqleJS_Service.php</code>.</p></li>
@@ -282,67 +323,66 @@ $&gt; docker-compose stop</code></pre>
 <li>File names in the <code>results/</code> folder contain a random string, so it is not possible to access the submitted data without listing the whole directory</li>
 </ul>
 <h1 id="internals">6. Internals</h1>
-<div class="figure">
-<img src="https://s14.postimg.cc/xozlybqdd/schematic.png" alt="BeaqleJS functional blocks" />
-<p class="caption">BeaqleJS functional blocks</p>
-</div>
+<figure>
+<img src="https://s14.postimg.cc/xozlybqdd/schematic.png" alt="BeaqleJS functional blocks" /><figcaption>BeaqleJS functional blocks</figcaption>
+</figure>
 <p>The general structure of BeaqleJS can be divided in three blocks as visualised in the diagram above. There is a common HTML5 <code>index.html</code> file to hold the main HTML structure with some basic place holder blocks whose content will be dynamically created by the JavaScript backend. The styling is completely independent and done with the help of cascading style sheets (CSS). Style sheets, config files and all necessary JavaScript libraries are loaded in the header of the <code>index.html</code>. Most of the descriptive text, like introduction and instructions, are placed in hidden blocks inside this file and their visibility is controlled by the scripts. For the user interface and to simplifiy Document Object Model (DOM) manipulations, the well known <a href="https://jquery.com/">jQuery</a> and <a href="http://jqueryui.com/">jQueryUI</a> libraries are used.</p>
 <p>The JavaScript backend consists of two main classes. The first one is the <code>AudioPool</code> which takes care of audio playback and buffering. It pools a set of HTML5 <code>&lt;audio&gt;</code>-tags in a certain AudioPool <code>&lt;div&gt;</code>-tag. There are simple functions to add and load a new file, connect and address it with an ID, manage playback and looping as well as synchronized pause and stop operations.</p>
-<p>The <code>ListeningTest</code> class provides the main functions of an abstract listening test. This includes the setup and management of basic playback controls (play, pause, looping, time line display, ...), reading of the test configuration as well as storage of the results and also main control over the test sequence.</p>
+<p>The <code>ListeningTest</code> class provides the main functions of an abstract listening test. This includes the setup and management of basic playback controls (play, pause, looping, time line display, …), reading of the test configuration as well as storage of the results and also main control over the test sequence.</p>
 <p>To create a certain test type the abstract <code>ListeningTest</code> class is inherited and specific functions for the actual arrangement of test items or storage and evaluation of the results need to be implemented. Based on this modular approach it is very easy to extend the framework with additional test types or to create variants of existing ones without the need to reimplement all the necessary basics.</p>
 <p>If the test is performed distributed over the internet or on several local computers, the <code>ListeningTest</code> main class is also able to send the final ratings to a web service for centralised collection and evaluation.</p>
 <h2 id="creating-a-new-test-class">6.1 Creating a new test class</h2>
 <p>A new test class has to inherit the base functionality from the main <code>ListeningTest</code> class. Inheritance in JavaScript is achieved by prototypes and this means to define a new class <code>MyTest</code> and then set its prototype to the base class. As this overwrites the constructor it has to be reset to the child constructor afterwards:</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="co">// inherit from ListeningTest</span>
-<span class="kw">function</span> <span class="at">MyTest</span>(TestData) <span class="op">{</span>
-  <span class="va">ListeningTest</span>.<span class="at">apply</span>(<span class="kw">this</span><span class="op">,</span> arguments)<span class="op">;</span>
-<span class="op">}</span>
-<span class="va">MyTest</span>.<span class="at">prototype</span> <span class="op">=</span> <span class="kw">new</span> <span class="at">ListeningTest</span>()<span class="op">;</span>
-<span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">constructor</span> <span class="op">=</span> MyTest<span class="op">;</span>
-
-<span class="co">// implement the necessary functions</span>
-<span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">createTestDOM</span> <span class="op">=</span> ...
-<span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">saveRatings</span>   <span class="op">=</span> ...
-<span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">readRatings</span>   <span class="op">=</span> ...
-<span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">formatResults</span> <span class="op">=</span> ...</code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode javascript"><code class="sourceCode javascript"><a class="sourceLine" id="cb15-1" data-line-number="1"><span class="co">// inherit from ListeningTest</span></a>
+<a class="sourceLine" id="cb15-2" data-line-number="2"><span class="kw">function</span> <span class="at">MyTest</span>(TestData) <span class="op">{</span></a>
+<a class="sourceLine" id="cb15-3" data-line-number="3">  <span class="va">ListeningTest</span>.<span class="at">apply</span>(<span class="kw">this</span><span class="op">,</span> arguments)<span class="op">;</span></a>
+<a class="sourceLine" id="cb15-4" data-line-number="4"><span class="op">}</span></a>
+<a class="sourceLine" id="cb15-5" data-line-number="5"><span class="va">MyTest</span>.<span class="at">prototype</span> <span class="op">=</span> <span class="kw">new</span> <span class="at">ListeningTest</span>()<span class="op">;</span></a>
+<a class="sourceLine" id="cb15-6" data-line-number="6"><span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">constructor</span> <span class="op">=</span> MyTest<span class="op">;</span></a>
+<a class="sourceLine" id="cb15-7" data-line-number="7"></a>
+<a class="sourceLine" id="cb15-8" data-line-number="8"><span class="co">// implement the necessary functions</span></a>
+<a class="sourceLine" id="cb15-9" data-line-number="9"><span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">createTestDOM</span> <span class="op">=</span> ...</a>
+<a class="sourceLine" id="cb15-10" data-line-number="10"><span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">saveRatings</span>   <span class="op">=</span> ...</a>
+<a class="sourceLine" id="cb15-11" data-line-number="11"><span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">readRatings</span>   <span class="op">=</span> ...</a>
+<a class="sourceLine" id="cb15-12" data-line-number="12"><span class="va">MyTest</span>.<span class="va">prototype</span>.<span class="at">formatResults</span> <span class="op">=</span> ...</a></code></pre></div>
 <p>The child class can access the <code>TestState</code> and the <code>TestConfig</code> structures from the parent:</p>
-<div class="sourceCode"><pre class="sourceCode javascript"><code class="sourceCode javascript"><span class="va">ListeningTest</span>.<span class="at">TestState</span> <span class="op">=</span> <span class="op">{</span>
-    <span class="co">// main public members</span>
-    <span class="st">&#39;CurrentTest&#39;</span><span class="op">:</span> <span class="op">-</span><span class="dv">1</span><span class="op">,</span>
-    <span class="st">&#39;TestIsRunning&#39;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>
-    <span class="st">&#39;FileMappings&#39;</span><span class="op">:</span> <span class="op">{},</span>
-    <span class="st">&#39;Ratings&#39;</span><span class="op">:</span> <span class="op">{},</span>
-    <span class="st">&#39;EvalResults&#39;</span><span class="op">:</span> <span class="op">{},</span>
-    <span class="co">// ...</span>
-    <span class="co">// optionally add own fields</span>
-    <span class="co">// ...</span>
-<span class="op">}</span>
-
-<span class="va">ListeningTest</span>.<span class="at">TestConfig</span> <span class="op">=</span> <span class="op">{</span>
-    <span class="st">&quot;TestName&quot;</span><span class="op">:</span> <span class="st">&quot;Test&quot;</span><span class="op">,</span>
-    <span class="st">&quot;LoopByDefault&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>
-    <span class="st">&quot;EnableABLoop&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span>
-    <span class="st">&quot;EnableOnlineSubmission&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span>
-    <span class="st">&quot;BeaqleServiceURL&quot;</span><span class="op">:</span> <span class="st">&quot;http://...&quot;</span><span class="op">,</span>
-    <span class="st">&quot;SupervisorContact&quot;</span><span class="op">:</span> <span class="st">&quot;super@visor.com&quot;</span><span class="op">,</span>
-    <span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [
-        <span class="op">{</span>
-            <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Testset 1&quot;</span><span class="op">,</span>
-            <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span>
-                <span class="co">// ...</span>
-            <span class="op">}</span>
-        <span class="op">},</span>
-        <span class="op">{</span>
-            <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Testset 2&quot;</span><span class="op">,</span>
-            <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span>
-                <span class="co">// ...</span>
-            <span class="op">}</span>
-        <span class="op">}</span>
-        ]<span class="op">,</span>
-    <span class="co">// ...</span>
-    <span class="co">// further test specific settings</span>
-    <span class="co">// ...</span>
-<span class="op">}</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode javascript"><code class="sourceCode javascript"><a class="sourceLine" id="cb16-1" data-line-number="1"><span class="va">ListeningTest</span>.<span class="at">TestState</span> <span class="op">=</span> <span class="op">{</span></a>
+<a class="sourceLine" id="cb16-2" data-line-number="2">    <span class="co">// main public members</span></a>
+<a class="sourceLine" id="cb16-3" data-line-number="3">    <span class="st">&#39;CurrentTest&#39;</span><span class="op">:</span> <span class="dv">-1</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-4" data-line-number="4">    <span class="st">&#39;TestIsRunning&#39;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-5" data-line-number="5">    <span class="st">&#39;FileMappings&#39;</span><span class="op">:</span> <span class="op">{},</span></a>
+<a class="sourceLine" id="cb16-6" data-line-number="6">    <span class="st">&#39;Ratings&#39;</span><span class="op">:</span> <span class="op">{},</span></a>
+<a class="sourceLine" id="cb16-7" data-line-number="7">    <span class="st">&#39;EvalResults&#39;</span><span class="op">:</span> <span class="op">{},</span></a>
+<a class="sourceLine" id="cb16-8" data-line-number="8">    <span class="co">// ...</span></a>
+<a class="sourceLine" id="cb16-9" data-line-number="9">    <span class="co">// optionally add own fields</span></a>
+<a class="sourceLine" id="cb16-10" data-line-number="10">    <span class="co">// ...</span></a>
+<a class="sourceLine" id="cb16-11" data-line-number="11"><span class="op">}</span></a>
+<a class="sourceLine" id="cb16-12" data-line-number="12"></a>
+<a class="sourceLine" id="cb16-13" data-line-number="13"><span class="va">ListeningTest</span>.<span class="at">TestConfig</span> <span class="op">=</span> <span class="op">{</span></a>
+<a class="sourceLine" id="cb16-14" data-line-number="14">    <span class="st">&quot;TestName&quot;</span><span class="op">:</span> <span class="st">&quot;Test&quot;</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-15" data-line-number="15">    <span class="st">&quot;LoopByDefault&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-16" data-line-number="16">    <span class="st">&quot;EnableABLoop&quot;</span><span class="op">:</span> <span class="kw">true</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-17" data-line-number="17">    <span class="st">&quot;EnableOnlineSubmission&quot;</span><span class="op">:</span> <span class="kw">false</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-18" data-line-number="18">    <span class="st">&quot;BeaqleServiceURL&quot;</span><span class="op">:</span> <span class="st">&quot;http://...&quot;</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-19" data-line-number="19">    <span class="st">&quot;SupervisorContact&quot;</span><span class="op">:</span> <span class="st">&quot;super@visor.com&quot;</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-20" data-line-number="20">    <span class="st">&quot;Testsets&quot;</span><span class="op">:</span> [</a>
+<a class="sourceLine" id="cb16-21" data-line-number="21">        <span class="op">{</span></a>
+<a class="sourceLine" id="cb16-22" data-line-number="22">            <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Testset 1&quot;</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-23" data-line-number="23">            <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span></a>
+<a class="sourceLine" id="cb16-24" data-line-number="24">                <span class="co">// ...</span></a>
+<a class="sourceLine" id="cb16-25" data-line-number="25">            <span class="op">}</span></a>
+<a class="sourceLine" id="cb16-26" data-line-number="26">        <span class="op">},</span></a>
+<a class="sourceLine" id="cb16-27" data-line-number="27">        <span class="op">{</span></a>
+<a class="sourceLine" id="cb16-28" data-line-number="28">            <span class="st">&quot;Name&quot;</span><span class="op">:</span> <span class="st">&quot;Testset 2&quot;</span><span class="op">,</span></a>
+<a class="sourceLine" id="cb16-29" data-line-number="29">            <span class="st">&quot;Files&quot;</span><span class="op">:</span> <span class="op">{</span></a>
+<a class="sourceLine" id="cb16-30" data-line-number="30">                <span class="co">// ...</span></a>
+<a class="sourceLine" id="cb16-31" data-line-number="31">            <span class="op">}</span></a>
+<a class="sourceLine" id="cb16-32" data-line-number="32">        <span class="op">}</span></a>
+<a class="sourceLine" id="cb16-33" data-line-number="33">        ]<span class="op">,</span></a>
+<a class="sourceLine" id="cb16-34" data-line-number="34">    <span class="co">// ...</span></a>
+<a class="sourceLine" id="cb16-35" data-line-number="35">    <span class="co">// further test specific settings</span></a>
+<a class="sourceLine" id="cb16-36" data-line-number="36">    <span class="co">// ...</span></a>
+<a class="sourceLine" id="cb16-37" data-line-number="37"><span class="op">}</span></a></code></pre></div>
 <p>The <code>TestState</code> should be used to store random file mappings, ratings and other status variables, but can also be dynamically expanded with specific fields required by the child class. The <code>TestConfig</code> structure is just a mapping of the BeaqleJS config file into the class namespace. It has to contain at least the fields and structure as given above but it is possible to add additional sections which are required by the child class.</p>
 <p>Every new test class has to implement at least four new functions:</p>
 <ul>

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ var TestConfig = {
   "MaxTestsPerRun": -1,              // <=  Only run a random subset of all available
                                      //     tests, set to -1 to disable
   "AudioRoot": "",                   // <=  path to prepend to all audio URLs in the testsets
+  "Repeat": 1,                       // <=  Each testset will be repeated x times
+  "GroupRepeated": true,             // <=  If set to false, automatically replicated testsets gets split apart when randomization is enabled
   "Testsets": [ {...}, {...}, ... ], // <=  Definition of test sets and files, more
                                      //     details below
 }


### PR DESCRIPTION
This adds a `Repeat` option that automatically duplicates testsets. This is useful for ABX tests, where  multiple attempts are necessary to get statistically significant results.

However, `RandomizeFileOrder` shuffles the identical tracks apart, which may or may not be desired, so another option `GroupRepeated` is added to mitigate that.

I regenerated `README.html` using `pandoc` as per the commands in `tools/generate_docs.sh`, hope I'm not doing it wrong.